### PR TITLE
Add artificial resource in order to wait for cluster to be in ready s…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,12 @@ variable "api_url" {
   default     = "https://api.cast.ai"
 }
 
+variable "api_token" {
+  type = string
+  description = "CAST AI API token created in console.cast.ai API Access keys section."
+  sensitive = true
+}
+
 variable "autoscaler_policies_json" {
   type        = string
   description = "Optional json object to override CAST AI cluster autoscaler policies"
@@ -142,4 +148,10 @@ variable "kvisor_version" {
   description = "Version of kvisor chart. Default latest"
   type        = string
   default     = null
+}
+
+variable "wait_for_cluster_ready" {
+  type        = bool
+  description = "Wait for cluster to be ready before finishing the module execution"
+  default     = true
 }


### PR DESCRIPTION
…tate

This commit introduces a change that will block module completion up until created cluster is in the Ready state.

Natural candidate for cluster ready state is castai_xxx_cluster resource creation step. Hoverer as cluster resource needs to finish its creation in order to run helm charts that actually deploys components that makes cluster to transit to ready state we need to introduce custom resource that will depend on helm charts resources that will pool ready state.

To accomplish this null_resource was introduced that pools created cluster status until it is in ready state.