### PR TITLE
Fix default value for optional variable autoscaler_policies_json

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "castai_api_token" {
 variable "autoscaler_policies_json" {
   type        = string
   description = "Optional json object to override CAST AI cluster autoscaler policies"
-  default     = ""
+  default     = null
 }
 
 variable "delete_nodes_on_disconnect" {


### PR DESCRIPTION
```
Error: failed to deserialize JSON: unexpected end of JSON input
│
│   with module.castai-eks-cluster.castai_autoscaler.castai_autoscaler_policies,
│   on .terraform/modules/castai-eks-cluster/main.tf line 344, in resource "castai_autoscaler" "castai_autoscaler_policies":
│  344:   autoscaler_policies_json = var.autoscaler_policies_json
```