### PR TITLE
bugfix: EKS terraform module node templates with the updated constrains

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ module "castai-eks-cluster" {
         instance_families             = {
           exclude = ["m5"]
         }
-        compute_optimized_status = false
-        storage_optimized_status = false
+        compute_optimized_status = enabled
+        storage_optimized_status = disabled
         is_gpu_only              = false
         architectures            = ["amd64"]
       }

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ module "castai-eks-cluster" {
         instance_families             = {
           exclude = ["m5"]
         }
-        compute_optimized = false
-        storage_optimized = false
-        is_gpu_only       = false
-        architectures     = ["amd64"]
+        compute_optimized_status = false
+        storage_optimized_status = false
+        is_gpu_only              = false
+        architectures            = ["amd64"]
       }
     }
   }
@@ -304,9 +304,9 @@ terraform-docs markdown table . --output-file README.md
 
 | Name | Version |
 |------|---------|
-| <a name="provider_castai"></a> [castai](#provider\_castai) | >= 6.6.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.0.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_castai"></a> [castai](#provider\_castai) | 6.7.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.13.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -323,10 +323,12 @@ No modules.
 | [castai_node_template.this](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/node_template) | resource |
 | [helm_release.castai_agent](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.castai_cluster_controller](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.castai_egressd](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.castai_evictor](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.castai_kvisor](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.castai_pod_pinner](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.castai_spot_handler](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.castai_workload_autoscaler](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [null_resource.wait_for_cluster](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 
 ## Inputs
@@ -351,10 +353,14 @@ No modules.
 | <a name="input_cluster_controller_version"></a> [cluster\_controller\_version](#input\_cluster\_controller\_version) | Version of castai-cluster-controller helm chart. Default latest | `string` | `null` | no |
 | <a name="input_default_node_configuration"></a> [default\_node\_configuration](#input\_default\_node\_configuration) | ID of the default node configuration | `string` | n/a | yes |
 | <a name="input_delete_nodes_on_disconnect"></a> [delete\_nodes\_on\_disconnect](#input\_delete\_nodes\_on\_disconnect) | Optionally delete Cast AI created nodes when the cluster is destroyed | `bool` | `false` | no |
+| <a name="input_egressd_values"></a> [egressd\_values](#input\_egressd\_values) | List of YAML formatted string with egressd values | `list(string)` | `[]` | no |
+| <a name="input_egressd_version"></a> [egressd\_version](#input\_egressd\_version) | Version of castai-egressd helm chart. Default latest | `string` | `null` | no |
 | <a name="input_evictor_values"></a> [evictor\_values](#input\_evictor\_values) | List of YAML formatted string with evictor values | `list(string)` | `[]` | no |
 | <a name="input_evictor_version"></a> [evictor\_version](#input\_evictor\_version) | Version of castai-evictor chart. Default latest | `string` | `null` | no |
 | <a name="input_grpc_url"></a> [grpc\_url](#input\_grpc\_url) | gRPC endpoint used by pod-pinner | `string` | `"grpc.cast.ai:443"` | no |
+| <a name="input_install_egressd"></a> [install\_egressd](#input\_install\_egressd) | Optional flag for installation of Egressd (Network cost monitoring) (https://docs.cast.ai/docs/network-cost) | `bool` | `false` | no |
 | <a name="input_install_security_agent"></a> [install\_security\_agent](#input\_install\_security\_agent) | Optional flag for installation of security agent (https://docs.cast.ai/product-overview/console/security-insights/) | `bool` | `false` | no |
+| <a name="input_install_workload_autoscaler"></a> [install\_workload\_autoscaler](#input\_install\_workload\_autoscaler) | Optional flag for installation of workload autoscaler (https://docs.cast.ai/docs/workload-autoscaling-configuration) | `bool` | `false` | no |
 | <a name="input_kvisor_values"></a> [kvisor\_values](#input\_kvisor\_values) | List of YAML formatted string with kvisor values | `list(string)` | `[]` | no |
 | <a name="input_kvisor_version"></a> [kvisor\_version](#input\_kvisor\_version) | Version of kvisor chart. Default latest | `string` | `null` | no |
 | <a name="input_node_configurations"></a> [node\_configurations](#input\_node\_configurations) | Map of EKS node configurations to create | `any` | `{}` | no |
@@ -362,6 +368,8 @@ No modules.
 | <a name="input_spot_handler_values"></a> [spot\_handler\_values](#input\_spot\_handler\_values) | List of YAML formatted string with spot-handler values | `list(string)` | `[]` | no |
 | <a name="input_spot_handler_version"></a> [spot\_handler\_version](#input\_spot\_handler\_version) | Version of castai-spot-handler helm chart. Default latest | `string` | `null` | no |
 | <a name="input_wait_for_cluster_ready"></a> [wait\_for\_cluster\_ready](#input\_wait\_for\_cluster\_ready) | Wait for cluster to be ready before finishing the module execution, this option requires `castai_api_token` to be set | `bool` | `false` | no |
+| <a name="input_workload_autoscaler_values"></a> [workload\_autoscaler\_values](#input\_workload\_autoscaler\_values) | List of YAML formatted string with cluster-workload-autoscaler values | `list(string)` | `[]` | no |
+| <a name="input_workload_autoscaler_version"></a> [workload\_autoscaler\_version](#input\_workload\_autoscaler\_version) | Version of castai-workload-autoscaler helm chart. Default latest | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -73,8 +73,8 @@ resource "castai_node_template" "this" {
   dynamic "constraints" {
     for_each = flatten([lookup(each.value, "constraints", [])])
     content {
-      compute_optimized_status                    = try(constraints.value.compute_optimized_status, false)
-      storage_optimized_status                    = try(constraints.value.storage_optimized_status, false)
+      compute_optimized_status                    = try(constraints.value.compute_optimized_status, null)
+      storage_optimized_status                    = try(constraints.value.storage_optimized_status, null)
       is_gpu_only                                 = try(constraints.value.is_gpu_only, false)
       spot                                        = try(constraints.value.spot, false)
       on_demand                                   = try(constraints.value.on_demand, null)

--- a/main.tf
+++ b/main.tf
@@ -256,6 +256,7 @@ resource "helm_release" "castai_cluster_controller" {
 # CAST.AI Workload Autoscaler configuration         #
 #---------------------------------------------------#
 resource "helm_release" "castai_workload_autoscaler" {
+  count            = var.install_workload_autoscaler ? 1 : 0
   name             = "castai-workload-autoscaler"
   repository       = "https://castai.github.io/helm-charts"
   chart            = "castai-workload-autoscaler"
@@ -288,6 +289,7 @@ resource "helm_release" "castai_workload_autoscaler" {
 # CAST.AI Network Cost Monitoring configuration     #
 #---------------------------------------------------#
 resource "helm_release" "castai_egressd" {
+  count            = var.install_egressd ? 1 : 0
   name             = "castai-egressd"
   repository       = "https://castai.github.io/helm-charts"
   chart            = "egressd"

--- a/main.tf
+++ b/main.tf
@@ -73,8 +73,8 @@ resource "castai_node_template" "this" {
   dynamic "constraints" {
     for_each = flatten([lookup(each.value, "constraints", [])])
     content {
-      compute_optimized                           = try(constraints.value.compute_optimized, false)
-      storage_optimized                           = try(constraints.value.storage_optimized, false)
+      compute_optimized_status                    = try(constraints.value.compute_optimized_status, false)
+      storage_optimized_status                    = try(constraints.value.storage_optimized_status, false)
       is_gpu_only                                 = try(constraints.value.is_gpu_only, false)
       spot                                        = try(constraints.value.spot, false)
       on_demand                                   = try(constraints.value.on_demand, null)

--- a/main.tf
+++ b/main.tf
@@ -308,7 +308,7 @@ resource "helm_release" "castai_egressd" {
 
   set {
     name  = "castai.apiKey"
-    value = var.castai_api_token
+    value = castai_eks_cluster.my_castai_cluster.cluster_token
   }
 
   set {

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,10 @@ variable "api_url" {
 }
 
 variable "castai_api_token" {
-  type = string
+  type        = string
   description = "Optional CAST AI API token created in console.cast.ai API Access keys section. Used only when `wait_for_cluster_ready` is set to true"
-  sensitive = true
-  default = ""
+  sensitive   = true
+  default     = ""
 }
 
 variable "grpc_url" {
@@ -167,4 +167,16 @@ variable "wait_for_cluster_ready" {
   type        = bool
   description = "Wait for cluster to be ready before finishing the module execution, this option requires `castai_api_token` to be set"
   default     = false
+}
+
+variable "workload_autoscaler_version" {
+  description = "Version of castai-workload-autoscaler helm chart. Default latest"
+  type        = string
+  default     = null
+}
+
+variable "workload_autoscaler_values" {
+  description = "List of YAML formatted string with cluster-workload-autoscaler values"
+  type        = list(string)
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -180,3 +180,14 @@ variable "workload_autoscaler_values" {
   type        = list(string)
   default     = []
 }
+variable "egressd_version" {
+  description = "Version of castai-egressd helm chart. Default latest"
+  type        = string
+  default     = null
+}
+
+variable "egressd_values" {
+  description = "List of YAML formatted string with egressd values"
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -168,6 +168,11 @@ variable "wait_for_cluster_ready" {
   description = "Wait for cluster to be ready before finishing the module execution, this option requires `castai_api_token` to be set"
   default     = false
 }
+variable "install_workload_autoscaler" {
+  type        = bool
+  default     = false
+  description = "Optional flag for installation of workload autoscaler (https://docs.cast.ai/docs/workload-autoscaling-configuration)"
+}
 
 variable "workload_autoscaler_version" {
   description = "Version of castai-workload-autoscaler helm chart. Default latest"
@@ -179,6 +184,11 @@ variable "workload_autoscaler_values" {
   description = "List of YAML formatted string with cluster-workload-autoscaler values"
   type        = list(string)
   default     = []
+}
+variable "install_egressd" {
+  type        = bool
+  default     = false
+  description = "Optional flag for installation of Egressd (Network cost monitoring) (https://docs.cast.ai/docs/network-cost)"
 }
 variable "egressd_version" {
   description = "Version of castai-egressd helm chart. Default latest"


### PR DESCRIPTION
Deprecate `compute_optimized` and `storage_optimized` constraints and introduce `compute_optimized_status` and `storage_optimized_status` to allow empty values

Reference - https://github.com/castai/terraform-provider-castai/pull/306

This change has been already pushed into the CAST.AI module which is breaking the terraform-castai-eks-cluster module.

cc- @varnastadeus @aldor007 