### PR TITLE
fix: add castai_agent chart as dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -546,6 +546,8 @@ resource "helm_release" "castai_evictor_ext" {
 
   version = var.evictor_ext_version
   values  = var.evictor_ext_values
+
+  depends_on = [helm_release.castai_agent]
 }
 
 resource "helm_release" "castai_pod_pinner" {


### PR DESCRIPTION
`castai-evictor-ext` should be placed in the `castai-agent` namespace and depend on the `castai_agent` chart. Otherwise, it will encounter a namespace error during the initial installation.