### PR TITLE
Remove deprecated autoscaler_policies_json from example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ module "castai-eks-cluster" {
   aws_cluster_name   = var.cluster_id
 
   aws_assume_role_arn      = module.castai-eks-role-iam.role_arn
-  autoscaler_policies_json = var.autoscaler_policies_json
 
   // Default node configuration will be used for all CAST provisioned nodes unless specific configuration is requested.
   default_node_configuration = module.cast-eks-cluster.castai_node_configurations["default"]


### PR DESCRIPTION
As per the autoscaler_policies_json variable description, it's in deprecated status

> Optional json object to override CAST AI cluster autoscaler policies. Deprecated, use `autoscaler_settings` instead.

Therefore I think we should remove it from the usage example in readme, to avoid confusing end users. 

I'm not sure how the release process looks like for this, but I'll probably have a few more PR's with some minor doc changes, so if possible we can release those once we have some actual code changes. 