### PR TITLE
making Pod mutator deployment optioanl

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -341,6 +341,7 @@ resource "helm_release" "castai_cluster_controller_self_managed" {
 
 # Helm Release for CAST AI Pod Mutator
 resource "helm_release" "castai_pod_mutator" {
+  count            = var.install_pod_mutator ? 1 : 0
   name             = "castai-pod-mutator"
   repository       = "https://castai.github.io/helm-charts"
   chart            = "castai-pod-mutator"

--- a/variables.tf
+++ b/variables.tf
@@ -270,6 +270,12 @@ variable "self_managed" {
   description = "Whether CAST AI components' upgrades are managed by a customer; by default upgrades are managed CAST AI central system."
 }
 
+variable "install_pod_mutator" {
+  description = "Set to true to install the CAST AI Pod Mutator"
+  type        = bool
+  default     = false # Change to true if you want it enabled by default
+}
+
 variable "pod_mutator_version" {
   description = "Version of castai-pod-mutator helm chart. Default latest"
   type        = string


### PR DESCRIPTION
Some customer raised concern as the pod mutator deployment requires the Org ID..so making it optional is better so customer has control if they want to install it or not