### PR TITLE
chore!: move to helm provider v3

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,44 @@
+locals {
+  # Common conditional non-sensitive values that we pass to helm_releases.
+  # Set up as lists so they can be concatenated.
+  set_apiurl = var.api_url != "" ? [{
+    name  = "castai.apiURL"
+    value = var.api_url
+  }] : []
+  set_cluster_id = [{
+    name  = "castai.clusterID"
+    value = castai_eks_cluster.my_castai_cluster.id
+  }]
+  set_organization_id = var.organization_id != "" ? [{
+    name  = "castai.organizationID"
+    value = var.organization_id
+  }] : []
+  set_agent_aws_iam_service_account_role_arn = var.agent_aws_iam_service_account_role_arn != "" ? [{
+    name  = "serviceAccount.annotations.eks\\.\\amazonaws\\.\\com/role-arn"
+    value = var.agent_aws_iam_service_account_role_arn
+  }] : []
+  set_grpc_url = var.grpc_url != "" ? [{
+    name  = "castai.grpcURL"
+    value = var.grpc_url
+  }] : []
+  set_pod_labels = [for k, v in var.castai_components_labels : {
+    name  = "podLabels.${k}"
+    value = v
+  }]
+
+
+  # Common conditional SENSITIVE values that we pass to helm_releases.
+  # Set up as lists so they can be concatenated.
+  set_sensitive_apikey = [{
+    name  = "castai.apiKey"
+    value = castai_eks_cluster.my_castai_cluster.cluster_token
+  }]
+  set_sensitive_aws_access_key = var.agent_aws_access_key_id != "" ? [{
+    name  = "additionalSecretEnv.AWS_ACCESS_KEY_ID"
+    value = var.agent_aws_access_key_id
+  }] : []
+  set_sensitive_aws_secret_access_key = var.agent_aws_secret_access_key != "" ? [{
+    name  = "additionalSecretEnv.AWS_SECRET_ACCESS_KEY"
+    value = var.agent_aws_secret_access_key
+  }] : []
+}

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.0.0"
+      version = ">= 3.0.0"
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: adapting the Helm resources to the 3.x version of Helm provider. No longer compatible with 2.x versions of the Helm provider.

The [v3 release of the Helm provider](https://github.com/hashicorp/terraform-provider-helm/releases/tag/v3.0.0) came with a set of breaking changes around certain attributes becoming nested objects instead of individual blocks (e.g. `set` and `set_sensitive`). This PR adapts the module to these changes following the [migration guide](https://github.com/hashicorp/terraform-provider-helm/blob/v3.0.0/docs/guides/v3-upgrade-guide.md) of the helm provider. 

## Proof of Work

To make sure that the new version will generte the same underlying Helm releases, I've made the following changes to get the manifests and compare them before and after this change:

- Removed all resources not related to the Helm releases (`castai_eks_cluster`, etc.) as they won't change. I've hardcoded dummy values where we needed the outputs of these resources (e.g. `castai_eks_cluster.my_castai_cluster.id`)
- I've changed every `helm_release` to `helm_template`. Had to do minor trivial changes to make this work (e.g. remove `cleanup_on_fail` attributes).
- I've added a Terraform output for every `helm_template` (17 in total) like this:
```terraform
output "castai_agent" {
  value = data.helm_template.castai_agent.manifests
} 
```
- I've changed all the `install_*` variables to be default `true`, so we generate all Helm templates.

With these changes in place, I've run `terraform apply && terraform output` to save the generated Helm manifests. Comparing these outputs before and after this change revealed no changes, meaning the maniests will be exactly the same.

Note that this is not a completely exhaustive test as it doesn't verify all potential combination of all variables, but it proves that it will work with the defaults. To make up for some of this, I've also tested:
- default values but with `self_managed=true` ✅ 
- setting `autoscaler_settings.node_downscaler.evictor.enabled=true` (with `self_managed=true`). ✅ 

I've also tested this module version with the `castai` provider's `eks_cluster_autoscaler_policies` [example](https://github.com/castai/terraform-provider-castai/tree/master/examples/eks/eks_cluster_autoscaler_policies).