### PR TITLE
chore: fix Cluster is not ready after 10 minutes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -450,7 +450,7 @@ resource "null_resource" "wait_for_cluster" {
       API_KEY = var.castai_api_token
     }
     command = <<-EOT
-        RETRY_COUNT=20
+        RETRY_COUNT=60
         POOLING_INTERVAL=30
 
         for i in $(seq 1 $RETRY_COUNT); do
@@ -458,7 +458,7 @@ resource "null_resource" "wait_for_cluster" {
             curl -s ${var.api_url}/v1/kubernetes/external-clusters/${castai_eks_cluster.my_castai_cluster.id} -H "x-api-key: $API_KEY" | grep '"status"\s*:\s*"ready"' && exit 0
         done
 
-        echo "Cluster is not ready after 10 minutes"
+        echo "Cluster is not ready after 30 minutes"
         exit 1
     EOT
 


### PR DESCRIPTION
│ echo "Cluster is not ready after 10 minutes"
│ exit 1
│ ': exit status 1. Output: Cluster is not ready after 10 minutes