### PR TITLE
fix: fix kvisor GRPC address

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -21,6 +21,10 @@ locals {
     name  = "castai.grpcURL"
     value = var.grpc_url
   }] : []
+  set_kvisor_grpc_addr = var.kvisor_grpc_addr != "" ? [{
+    name  = "castai.grpcAddr"
+    value = var.kvisor_grpc_addr
+  }] : []
   set_pod_labels = [for k, v in var.castai_components_labels : {
     name  = "podLabels.${k}"
     value = v

--- a/main.tf
+++ b/main.tf
@@ -684,7 +684,7 @@ resource "helm_release" "castai_kvisor" {
       },
     ],
     local.set_cluster_id,
-    local.set_grpc_url,
+    local.set_kvisor_grpc_addr,
     [for k, v in var.kvisor_controller_extra_args : {
       name  = "controller.extraArgs.${k}"
       value = v
@@ -717,7 +717,7 @@ resource "helm_release" "castai_kvisor_self_managed" {
       },
     ],
     local.set_cluster_id,
-    local.set_grpc_url,
+    local.set_kvisor_grpc_addr,
     [for k, v in var.kvisor_controller_extra_args : {
       name  = "controller.extraArgs.${k}"
       value = v


### PR DESCRIPTION
Accidentally replaced the kvisor GRPC address with the general GRPC url in #133.

See the faulty change around here: https://github.com/castai/terraform-castai-eks-cluster/pull/133/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL861

<img width="1721" height="418" alt="image" src="https://github.com/user-attachments/assets/3b9af630-f80d-4dda-858e-8a3cdef2cde8" />

(Noticed this while working on the same change in `terraform-castai-gke-cluster`)