### PR TITLE
fix(castai-live): CLM helm chart is always self-managed for users

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1094,6 +1094,11 @@ resource "helm_release" "castai_live" {
   depends_on = [helm_release.castai_agent]
 }
 
+moved {
+  from = helm_release.castai_live_self_managed
+  to   = helm_release.castai_live
+}
+
 resource "castai_autoscaler" "castai_autoscaler_policies" {
   cluster_id = castai_eks_cluster.my_castai_cluster.id
 

--- a/main.tf
+++ b/main.tf
@@ -1025,39 +1025,7 @@ resource "helm_release" "castai_pod_mutator_self_managed" {
 }
 
 resource "helm_release" "castai_live" {
-  count = var.install_live && !var.self_managed ? 1 : 0
-
-  name             = "castai-live"
-  repository       = "https://castai.github.io/helm-charts"
-  chart            = "castai-live"
-  namespace        = "castai-agent"
-  create_namespace = true
-  cleanup_on_fail  = true
-  wait             = true
-
-  lifecycle {
-    ignore_changes = [version]
-  }
-
-  version = var.live_version
-  values  = var.live_values
-
-  set = concat(
-    var.install_live_cni ? [{ name = "castai-aws-vpc-cni.enabled", value = "true" }] : [],
-    local.set_cluster_id,
-    local.set_apiurl,
-    local.set_components_sets,
-  )
-
-  set_sensitive = concat(
-    local.set_sensitive_apikey,
-  )
-
-  depends_on = [helm_release.castai_agent]
-}
-
-resource "helm_release" "castai_live_self_managed" {
-  count = var.install_live && var.self_managed ? 1 : 0
+  count = var.install_live ? 1 : 0
 
   name             = "castai-live"
   repository       = "https://castai.github.io/helm-charts"


### PR DESCRIPTION
TF castai module has two kinds of helm resources - 'self-managed' and '(CAST.AI) managed'.
self-managed are for the customer to upgrade manually, while 'regular' (CAST.AI managed) are to be upgraded from the mothership.

CLM is not automatically upgraded through mothership. Customers must always manually upgrade it. Hence switching to 'always self-managed' one, and dropping the 'CAST.AI managed' version for it.