### PR TITLE
feat: add castai_workload_custom_metrics_data_source resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,23 @@ module "castai-eks-cluster" {
       excluded_containers = ["container-1", "container-2"]
     }
   }
+
+  workload_custom_metrics_data_sources = {
+    my-prometheus = {
+      prometheus = {
+        url     = "http://prometheus-server.monitoring.svc.cluster.local:9090"
+        timeout = "30s"
+        presets = ["jvm"]
+
+        metrics = [
+          {
+            name  = "http_requests_total"
+            query = "sum(rate(http_requests_total[5m])) by (pod)"
+          }
+        ]
+      }
+    }
+  }
 }
 ```
 
@@ -916,6 +933,7 @@ terraform-docs markdown table . --output-file README.md
 | [castai_node_configuration.this](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/node_configuration) | resource |
 | [castai_node_configuration_default.this](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/node_configuration_default) | resource |
 | [castai_node_template.this](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/node_template) | resource |
+| [castai_workload_custom_metrics_data_source.this](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/workload_custom_metrics_data_source) | resource |
 | [castai_workload_scaling_policy.this](https://registry.terraform.io/providers/castai/castai/latest/docs/resources/workload_scaling_policy) | resource |
 | [helm_release.castai_agent](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.castai_ai_optimizer_proxy](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
@@ -1008,6 +1026,7 @@ terraform-docs markdown table . --output-file README.md
 | <a name="input_workload_autoscaler_exporter_version"></a> [workload\_autoscaler\_exporter\_version](#input\_workload\_autoscaler\_exporter\_version) | Version of castai-workload-autoscaler-exporter helm chart. Default latest | `string` | `null` | no |
 | <a name="input_workload_autoscaler_values"></a> [workload\_autoscaler\_values](#input\_workload\_autoscaler\_values) | List of YAML formatted string with cluster-workload-autoscaler values | `list(string)` | `[]` | no |
 | <a name="input_workload_autoscaler_version"></a> [workload\_autoscaler\_version](#input\_workload\_autoscaler\_version) | Version of castai-workload-autoscaler helm chart. Default latest | `string` | `null` | no |
+| <a name="input_workload_custom_metrics_data_sources"></a> [workload\_custom\_metrics\_data\_sources](#input\_workload\_custom\_metrics\_data\_sources) | Map of workload custom metrics data sources to create | `any` | `{}` | no |
 | <a name="input_workload_scaling_policies"></a> [workload\_scaling\_policies](#input\_workload\_scaling\_policies) | Map of workload scaling policies to create | `any` | `{}` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -380,6 +380,29 @@ resource "castai_workload_scaling_policy" "this" {
   depends_on = [helm_release.castai_workload_autoscaler]
 }
 
+resource "castai_workload_custom_metrics_data_source" "this" {
+  for_each = { for k, v in var.workload_custom_metrics_data_sources : k => v }
+
+  cluster_id = castai_eks_cluster.my_castai_cluster.id
+  name       = try(each.value.name, each.key)
+
+  prometheus {
+    url     = each.value.prometheus.url
+    timeout = try(each.value.prometheus.timeout, null)
+    presets = try(each.value.prometheus.presets, null)
+
+    dynamic "metric" {
+      for_each = try(each.value.prometheus.metrics, [])
+      content {
+        name  = metric.value.name
+        query = metric.value.query
+      }
+    }
+  }
+
+  depends_on = [helm_release.castai_workload_autoscaler]
+}
+
 resource "helm_release" "castai_agent" {
   count = var.install_helm_apps ? 1 : 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,12 @@ variable "workload_scaling_policies" {
   default     = {}
 }
 
+variable "workload_custom_metrics_data_sources" {
+  type        = any
+  description = "Map of workload custom metrics data sources to create"
+  default     = {}
+}
+
 variable "install_security_agent" {
   type        = bool
   default     = false


### PR DESCRIPTION
## Summary
- Add `castai_workload_custom_metrics_data_source` resource to the module, allowing users to configure Prometheus custom metrics data sources via the `workload_custom_metrics_data_sources` variable
- Supports presets (e.g. `jvm`) and manually defined PromQL metrics
- Bump minimum provider version to `>= 8.26.0`

Related provider: https://github.com/castai/terraform-provider-castai/pull/669

## Test plan
- [x] `terraform validate` passes
- [x] Verify docs are correctly generated