### PR TITLE
fix: pass pod_cidrs instead of deprecated pod_cidr to omni-cluster module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1275,7 +1275,7 @@ data "aws_vpc" "eks_vpc" {
 module "castai_omni_cluster" {
   count   = var.install_omni && !var.self_managed ? 1 : 0
   source  = "castai/omni-cluster/castai"
-  version = "~> 2.0"
+  version = "~> 2.5"
 
   k8s_provider    = "eks"
   api_url         = var.api_url
@@ -1285,7 +1285,7 @@ module "castai_omni_cluster" {
   cluster_name    = var.aws_cluster_name
 
   api_server_address    = data.aws_eks_cluster.this[0].endpoint
-  pod_cidr              = data.aws_vpc.eks_vpc[0].cidr_block
+  pod_cidrs             = [data.aws_vpc.eks_vpc[0].cidr_block]
   service_cidr          = data.aws_eks_cluster.this[0].kubernetes_network_config[0].service_ipv4_cidr
   reserved_subnet_cidrs = var.omni_reserved_subnet_cidrs
   storage_provider      = var.omni_storage_provider


### PR DESCRIPTION
## Problem

Since `castai/omni-cluster` 2.4.0 (#56), the module validates its inputs with:

```hcl
condition = var.pod_cidrs == null || length(var.pod_cidrs) > 0
```

Terraform does not short-circuit `||`, so `length(var.pod_cidrs)` is evaluated even when `var.pod_cidrs` is null. Because this module still passes the deprecated `pod_cidr` (singular) and leaves `pod_cidrs` null, every EKS setup with `install_omni = true` now fails at plan time — the `~> 2.0` constraint resolves to omni-cluster 2.5.0 on any fresh `terraform init`:

```
Error: Invalid function argument

  on .terraform/modules/castai_eks_cluster.castai_omni_cluster/main.tf line 16, in resource "terraform_data" "pod_cidr_validation":
  16:       condition     = var.pod_cidrs == null || length(var.pod_cidrs) > 0
    ├────────────────
    │ while calling length(value)
    │ var.pod_cidrs is null

Invalid value for "value" parameter: argument must not be null.
```

## Fix

- Pass `pod_cidrs = [<vpc cidr>]` instead of the deprecated `pod_cidr` (same value, list form).
- Bump the omni-cluster constraint to `~> 2.5`: `pod_cidrs` only exists from 2.4.0, and a plain `terraform init` (without `-upgrade`) keeps a cached 2.0–2.3 module that would fail with `Unsupported argument`.
