### PR TITLE
fix: allow WOOP Dynamic threshold and Semi-automatic limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,17 @@ module "castai-eks-cluster" {
         look_back_period_seconds = 172800
         min                      = 0.1
         max                      = 2.0
+        # Dynamic change sensitivity (omit apply_threshold when strategy is set)
+        apply_threshold_strategy = {
+          type = "DEFAULT_ADAPTIVE"
+        }
+        # Semi-automatic CPU limits
+        limit = {
+          type                   = "MULTIPLIER"
+          multiplier             = 1.5
+          only_if_original_exist = true
+          only_if_original_lower = true
+        }
       }
 
       memory = {

--- a/main.tf
+++ b/main.tf
@@ -206,9 +206,11 @@ resource "castai_workload_scaling_policy" "this" {
   excluded_containers = try(each.value.excluded_containers, null)
 
   cpu {
-    function                 = try(each.value.cpu.function, "QUANTILE")
-    overhead                 = try(each.value.cpu.overhead, 0)
-    apply_threshold          = try(each.value.cpu.apply_threshold, 0.1)
+    function = try(each.value.cpu.function, "QUANTILE")
+    overhead = try(each.value.cpu.overhead, 0)
+    # Deprecated apply_threshold conflicts with apply_threshold_strategy on older providers;
+    # omit it when strategy is set so Dynamic/adaptive strategies can be configured.
+    apply_threshold          = try(each.value.cpu.apply_threshold_strategy, null) != null ? null : try(each.value.cpu.apply_threshold, 0.1)
     args                     = try(each.value.cpu.args, ["0.8"])
     look_back_period_seconds = try(each.value.cpu.look_back_period_seconds, null)
     min                      = try(each.value.cpu.min, null)
@@ -229,16 +231,20 @@ resource "castai_workload_scaling_policy" "this" {
     dynamic "limit" {
       for_each = try([each.value.cpu.limit], [])
       content {
-        type       = try(limit.value.type, null)
-        multiplier = try(limit.value.multiplier, null)
+        type                   = try(limit.value.type, null)
+        multiplier             = try(limit.value.multiplier, null)
+        only_if_original_exist = try(limit.value.only_if_original_exist, null)
+        only_if_original_lower = try(limit.value.only_if_original_lower, null)
       }
     }
   }
 
   memory {
-    function                 = try(each.value.memory.function, "MAX")
-    overhead                 = try(each.value.memory.overhead, 0.1)
-    apply_threshold          = try(each.value.memory.apply_threshold, 0.1)
+    function = try(each.value.memory.function, "MAX")
+    overhead = try(each.value.memory.overhead, 0.1)
+    # Deprecated apply_threshold conflicts with apply_threshold_strategy on older providers;
+    # omit it when strategy is set so Dynamic/adaptive strategies can be configured.
+    apply_threshold          = try(each.value.memory.apply_threshold_strategy, null) != null ? null : try(each.value.memory.apply_threshold, 0.1)
     args                     = try(each.value.memory.args, null)
     look_back_period_seconds = try(each.value.memory.look_back_period_seconds, null)
     min                      = try(each.value.memory.min, null)
@@ -259,8 +265,10 @@ resource "castai_workload_scaling_policy" "this" {
     dynamic "limit" {
       for_each = try([each.value.memory.limit], [])
       content {
-        type       = try(limit.value.type, null)
-        multiplier = try(limit.value.multiplier, null)
+        type                   = try(limit.value.type, null)
+        multiplier             = try(limit.value.multiplier, null)
+        only_if_original_exist = try(limit.value.only_if_original_exist, null)
+        only_if_original_lower = try(limit.value.only_if_original_lower, null)
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -121,7 +121,7 @@ variable "node_templates" {
 }
 
 variable "workload_scaling_policies" {
-  type = any
+  type        = any
   description = <<-EOT
     Map of workload scaling policies to create (passed through to castai_workload_scaling_policy).
 
@@ -137,7 +137,7 @@ variable "workload_scaling_policies" {
       requests × multiplier.
     - Both flags are optional booleans and may be combined; see provider docs for workload_scaling_policy.
   EOT
-  default = {}
+  default     = {}
 }
 
 variable "workload_custom_metrics_data_sources" {

--- a/variables.tf
+++ b/variables.tf
@@ -121,9 +121,23 @@ variable "node_templates" {
 }
 
 variable "workload_scaling_policies" {
-  type        = any
-  description = "Map of workload scaling policies to create"
-  default     = {}
+  type = any
+  description = <<-EOT
+    Map of workload scaling policies to create (passed through to castai_workload_scaling_policy).
+
+    Apply threshold:
+    - Prefer cpu/memory.apply_threshold_strategy (e.g. { type = "DEFAULT_ADAPTIVE" } for Dynamic).
+    - Deprecated apply_threshold is only set when apply_threshold_strategy is absent (default 0.1).
+    - If both are supplied, strategy wins and apply_threshold is omitted so older providers
+      that mark the fields as conflicting do not fail.
+
+    Resource limits (console Automatic / Semi-automatic map to MULTIPLIER + flags):
+    - limit.only_if_original_exist (bool) — only set limits when the workload originally had them.
+    - limit.only_if_original_lower (bool) — only raise limits when original limits are lower than
+      requests × multiplier.
+    - Both flags are optional booleans and may be combined; see provider docs for workload_scaling_policy.
+  EOT
+  default = {}
 }
 
 variable "workload_custom_metrics_data_sources" {


### PR DESCRIPTION
## Summary
- Omit deprecated `apply_threshold` when `apply_threshold_strategy` is set so Dynamic / adaptive change sensitivity can be configured without a provider schema conflict (common when both fields were previously always set).
- Forward `only_if_original_exist` and `only_if_original_lower` on CPU/memory `limit` blocks so Semi-automatic / Automatic limit modes work via the module (not just Custom multiplier).

Companion changes:
- Provider: https://github.com/castai/terraform-provider-castai/pull/763 (prefers strategy when both are set; this module fix remains needed for older provider versions and cleaner configs).
- GKE module: https://github.com/castai/terraform-castai-gke-cluster/pull/147
- AKS module: https://github.com/castai/terraform-castai-aks/pull/144

## Test plan
- [ ] `terraform validate` with a policy that sets only `apply_threshold_strategy = { type = "DEFAULT_ADAPTIVE" }` (no conflict)
- [ ] Policy with `limit = { type = "MULTIPLIER", multiplier = X, only_if_original_exist = true, only_if_original_lower = true }` shows Semi-automatic/Automatic in console after apply
- [ ] Policy with neither strategy nor custom threshold still defaults to Percentage 0.1 via `apply_threshold`
- [ ] Policy that only sets deprecated `apply_threshold` still works
- [x] Smoke-tested against local provider + local module on an existing EKS cluster (`smoke-module-woop`)