### PR TITLE
feat: add hpa_converters to workload scaling policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ module "castai-eks-cluster" {
       }
 
       excluded_containers = ["container-1", "container-2"]
+
+      # Convert existing HPA utilization (%) targets to AverageValue using the
+      # workload's original container requests. Ignored if HPA management is enabled.
+      hpa_converters = [
+        {
+          type = "AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS"
+        }
+      ]
     }
   }
 
@@ -916,7 +924,7 @@ terraform-docs markdown table . --output-file README.md
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.23.0 |
-| <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.26.0 |
+| <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.55.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
@@ -925,7 +933,7 @@ terraform-docs markdown table . --output-file README.md
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.23.0 |
-| <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.26.0 |
+| <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.55.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 
@@ -933,7 +941,7 @@ terraform-docs markdown table . --output-file README.md
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_castai_omni_cluster"></a> [castai\_omni\_cluster](#module\_castai\_omni\_cluster) | castai/omni-cluster/castai | ~> 2.0 |
+| <a name="module_castai_omni_cluster"></a> [castai\_omni\_cluster](#module\_castai\_omni\_cluster) | castai/omni-cluster/castai | ~> 2.5 |
 
 ## Resources
 
@@ -1041,7 +1049,7 @@ terraform-docs markdown table . --output-file README.md
 | <a name="input_workload_autoscaler_values"></a> [workload\_autoscaler\_values](#input\_workload\_autoscaler\_values) | List of YAML formatted string with cluster-workload-autoscaler values | `list(string)` | `[]` | no |
 | <a name="input_workload_autoscaler_version"></a> [workload\_autoscaler\_version](#input\_workload\_autoscaler\_version) | Version of castai-workload-autoscaler helm chart. Default latest | `string` | `null` | no |
 | <a name="input_workload_custom_metrics_data_sources"></a> [workload\_custom\_metrics\_data\_sources](#input\_workload\_custom\_metrics\_data\_sources) | Map of workload custom metrics data sources to create | `any` | `{}` | no |
-| <a name="input_workload_scaling_policies"></a> [workload\_scaling\_policies](#input\_workload\_scaling\_policies) | Map of workload scaling policies to create | `any` | `{}` | no |
+| <a name="input_workload_scaling_policies"></a> [workload\_scaling\_policies](#input\_workload\_scaling\_policies) | Map of workload scaling policies to create (passed through to castai\_workload\_scaling\_policy).<br/><br/>Apply threshold:<br/>- Prefer cpu/memory.apply\_threshold\_strategy (e.g. { type = "DEFAULT\_ADAPTIVE" } for Dynamic).<br/>- Deprecated apply\_threshold is only set when apply\_threshold\_strategy is absent (default 0.1).<br/>- If both are supplied, strategy wins and apply\_threshold is omitted so older providers<br/>  that mark the fields as conflicting do not fail.<br/><br/>Resource limits (console Automatic / Semi-automatic map to MULTIPLIER + flags):<br/>- limit.only\_if\_original\_exist (bool) — only set limits when the workload originally had them.<br/>- limit.only\_if\_original\_lower (bool) — only raise limits when original limits are lower than<br/>  requests × multiplier.<br/>- Both flags are optional booleans and may be combined; see provider docs for workload\_scaling\_policy. | `any` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -924,7 +924,7 @@ terraform-docs markdown table . --output-file README.md
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.23.0 |
-| <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.55.0 |
+| <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.56.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
@@ -933,7 +933,7 @@ terraform-docs markdown table . --output-file README.md
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.23.0 |
-| <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.55.0 |
+| <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.56.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 

--- a/main.tf
+++ b/main.tf
@@ -386,6 +386,13 @@ resource "castai_workload_scaling_policy" "this" {
     }
   }
 
+  dynamic "hpa_converters" {
+    for_each = try(each.value.hpa_converters, [])
+    content {
+      type = hpa_converters.value.type
+    }
+  }
+
   depends_on = [helm_release.castai_workload_autoscaler]
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     castai = {
       source  = "castai/castai"
-      version = ">= 8.55.0"
+      version = ">= 8.56.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     castai = {
       source  = "castai/castai"
-      version = ">= 8.49.0"
+      version = ">= 8.55.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
Propagates the `hpa_converters` block added in castai/terraform-provider-castai#774 to the cluster module.

When VPA is the sole optimization, this converts existing HPA utilization (%) targets to `AverageValue` using the workload's original container requests. If HPA management is enabled, it takes precedence over this setting.

### Changes
- `main.tf`: pass-through `dynamic "hpa_converters"` block on `castai_workload_scaling_policy`
- `README.md`: usage example + regenerated terraform-docs section
- `versions.tf`: bump castai provider to `>= 8.56.0`

### Usage
```hcl
workload_scaling_policies = {
  default = {
    hpa_converters = [
      {
        type = "AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS"
      }
    ]
  }
}
```
