### PR TITLE
feat: expose jvm.auto_instrument in workload_scaling_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ module "castai-eks-cluster" {
       }
 
       jvm = {
+        auto_instrument = true
         memory = {
           optimization = true
         }

--- a/main.tf
+++ b/main.tf
@@ -379,6 +379,8 @@ resource "castai_workload_scaling_policy" "this" {
   dynamic "jvm" {
     for_each = try([each.value.jvm], [])
     content {
+      auto_instrument = try(jvm.value.auto_instrument, null)
+
       dynamic "memory" {
         for_each = try([jvm.value.memory], [])
         content {

--- a/variables.tf
+++ b/variables.tf
@@ -136,6 +136,11 @@ variable "workload_scaling_policies" {
     - limit.only_if_original_lower (bool) — only raise limits when original limits are lower than
       requests × multiplier.
     - Both flags are optional booleans and may be combined; see provider docs for workload_scaling_policy.
+
+    JVM optimization:
+    - jvm.auto_instrument (bool) — when true, JMX exporter is automatically injected
+      into pods where a JVM runtime is detected.
+    - jvm.memory.optimization (bool) — enables JVM heap-size optimization.
   EOT
   default     = {}
 }


### PR DESCRIPTION
Exposes the `auto_instrument` boolean argument inside the `jvm` block of `castai_workload_scaling_policy`. This argument is already supported by the `castai/castai` provider (>= 8.57.0) and enables automatic injection of the JMX exporter into pods where JVM runtime is detected.

Changes:
- `main.tf`: map `jvm.auto_instrument` through the dynamic block
- `variables.tf`: document the new argument
- `README.md`: update example

Verification:
- `terraform fmt` passes
- `terraform validate` passes
- `tflint` passes

Note: The same change is needed in `terraform-castai-aks` and `terraform-castai-gke-cluster` to maintain cross-module parity. Those will follow in separate PRs.